### PR TITLE
Remove Pineapple and FireSpotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Hacker News for Bootstrapping
 Hacker News for Design
 
 * [Designer News](https://www.designernews.co) - Interesting links and events for design professionals.
-* [Pineapple](http://pineapple.io) - Tutorials and resources for designers and developers.
 
 ## Finance
 
@@ -52,7 +51,6 @@ Hacker News for Science
 
 Hacker News for Technology
 
-* [Firespotting](http://firespotting.com) - Interesting ideas and products.
 * [Golang News](https://golangnews.com) - Curated links and news about the Go Programming language
 * [Lobsters](https://lobste.rs) - Very similar to Hacker News, but with more emphasis on technical content.
 * [Product Hunt](https://www.producthunt.com) - A place to share the latest tech creations (apps, websites, hardware etc.).


### PR DESCRIPTION
Pineapple's website displays a "This Account has been suspended." message. The [Pineapple](https://twitter.com/pineappleio) Twitter account also hasn't tweeted in almost five years.

FireSpotting's website doesn't load at all. The [FireSpotting](https://twitter.com/firespotting) Twitter account hasn't tweeted in over five years.
